### PR TITLE
rpi5.yaml: switch to zephyr zephyr-dom0-xt

### DIFF
--- a/rpi5.yaml
+++ b/rpi5.yaml
@@ -12,7 +12,7 @@ variables:
 
   ZEPHYR_DOM0_DIR: "zephyr"
   ZEPHYR_DOM0_MACHINE: "rpi_5"
-  ZEPHYR_DOM0_TARGET: "zephyr/samples/hello_world"
+  ZEPHYR_DOM0_TARGET: "zephyr-dom0-xt"
   ZEPHYR_DOM0_BUILD_DIR: "build-dom0"
 
   DOMD_BUILD_DIR: "build-domd"
@@ -27,8 +27,8 @@ components:
     build-dir: "%{ZEPHYR_DOM0_DIR}"
     sources:
       - type: west
-        url: "https://github.com/xen-troops/zephyr.git"
-        rev: "rpi5_dev"
+        url: "https://github.com/xen-troops/zephyr-dom0-xt.git"
+        rev: "rpi5_dom0_dev"
 
     builder:
       type: zephyr


### PR DESCRIPTION
Now the simple Zephyr samples/hello_world app is used as Zen Dom0 example with zero functionality.

This patch switches Dom0 to thin zephyr-dom0-xt application which supports 2 domain cfg domD/DomU and enables xenlib command line interface.

Grygorii Strashko <grygorii_strashko@epam.com>