### PR TITLE
rpi5.yaml: add driver-domain to bblayers

### DIFF
--- a/rpi5.yaml
+++ b/rpi5.yaml
@@ -115,6 +115,7 @@ components:
         - "../meta-openembedded/meta-python"
         - "../meta-openembedded/meta-filesystems"
         - "../meta-xt-common/meta-xt-domx"
+        - "../meta-xt-common/meta-xt-driver-domain"
         - "../meta-xt-common/meta-xt-security"
         - "../meta-xt-rpi5"
         - "../meta-xt-rpi5-prod-devel"


### PR DESCRIPTION
meta-xt-driver-domain is needed to allow using recipes for backends, such as xen-network.