### PR TITLE
Dom0 add generation zephyr domu images and Unicraft sample image

### DIFF
--- a/get_unikraft.sh
+++ b/get_unikraft.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+wget https://github.com/aoscloud/demo-services/raw/main/monkey_zephyr/src/helloworld_xen-arm64 -O helloworld_xen-arm64
+

--- a/rpi5.yaml
+++ b/rpi5.yaml
@@ -15,6 +15,12 @@ variables:
   ZEPHYR_DOM0_TARGET: "zephyr-dom0-xt"
   ZEPHYR_DOM0_BUILD_DIR: "build-dom0"
 
+  ZEPHYR_DOMU1_DIR: "zephyr_sync"
+  ZEPHYR_DOMU1_BUILD_DIR: "build-sync"
+
+  ZEPHYR_DOMU2_DIR: "zephyr_blinky"
+  ZEPHYR_DOMU2_BUILD_DIR: "build-blinky"
+
   DOMD_BUILD_DIR: "build-domd"
   XT_XEN_DTBO_NAME: "%{SOC_FAMILY}-%{MACHINE}-xen.dtbo"
   XT_DOMD_DTB_NAME: "%{SOC_FAMILY}-%{MACHINE}-domd.dtb"
@@ -41,6 +47,40 @@ components:
         - "%{ZEPHYR_DOM0_BUILD_DIR}/zephyr/zephyr.bin"
       additional_deps:
         - "%{YOCTOS_WORK_DIR}/%{DOMD_BUILD_DIR}/tmp/deploy/images/%{MACHINE}/Image.gz"
+
+  domu_sync:
+    default: true
+    build-dir: "%{ZEPHYR_DOMU1_DIR}"
+    sources:
+      - type: west
+        url: "https://github.com/xen-troops/zephyr.git"
+        rev: "rpi5_dev"
+
+    builder:
+      type: zephyr
+      board: xenvm
+      target: zephyr/samples/synchronization
+      work_dir: "%{ZEPHYR_DOMU1_BUILD_DIR}"
+      target_images:
+        - "%{ZEPHYR_DOMU1_BUILD_DIR}/zephyr/zephyr.bin"
+
+  domu_blinky:
+    default: true
+    build-dir: "%{ZEPHYR_DOMU2_DIR}"
+    sources:
+      - type: west
+        url: "https://github.com/xen-troops/zephyr.git"
+        rev: "rpi5_dev"
+
+    builder:
+      type: zephyr
+      board: xenvm
+      target: zephyr/samples/basic/blinky
+      work_dir: "%{ZEPHYR_DOMU2_BUILD_DIR}"
+      snippets:
+        - "rpi_5_xen_domd"
+      target_images:
+        - "%{ZEPHYR_DOMU2_BUILD_DIR}/zephyr/zephyr.bin"
 
   domd:
     build-dir: "%{YOCTOS_WORK_DIR}"
@@ -197,6 +237,8 @@ images:
           "%{SOC_FAMILY}-%{MACHINE}-usb.dtbo": "%{YOCTOS_WORK_DIR}/%{DOMD_BUILD_DIR}/tmp/deploy/images/%{MACHINE}/%{SOC_FAMILY}-%{MACHINE}-usb.dtbo"
           "%{SOC_FAMILY}-%{MACHINE}-mmc.dtbo": "%{YOCTOS_WORK_DIR}/%{DOMD_BUILD_DIR}/tmp/deploy/images/%{MACHINE}/%{SOC_FAMILY}-%{MACHINE}-mmc.dtbo"
           "zephyr.bin": "%{ZEPHYR_DOM0_DIR}/%{ZEPHYR_DOM0_BUILD_DIR}/zephyr/zephyr.bin"
+          "dom0/z_sync.bin": "%{ZEPHYR_DOMU1_DIR}/%{ZEPHYR_DOMU1_BUILD_DIR}/zephyr/zephyr.bin"
+          "dom0/z_blinky.bin": "%{ZEPHYR_DOMU2_DIR}/%{ZEPHYR_DOMU2_BUILD_DIR}/zephyr/zephyr.bin"
 
 parameters:
   # Machines
@@ -230,6 +272,9 @@ parameters:
                 gpt_type: ebd0a0a2-b9e5-4433-87c0-68b6b72699c7
                 type: vfat
                 size: 128 MiB
+                items:
+                  "dom0/z_sync.bin": "%{ZEPHYR_DOMU1_DIR}/%{ZEPHYR_DOMU1_BUILD_DIR}/zephyr/zephyr.bin"
+                  "dom0/z_blinky.bin": "%{ZEPHYR_DOMU2_DIR}/%{ZEPHYR_DOMU2_BUILD_DIR}/zephyr/zephyr.bin"
 
   DOMD_ROOT:
     desc: "Domd root device"

--- a/rpi5.yaml
+++ b/rpi5.yaml
@@ -82,6 +82,16 @@ components:
       target_images:
         - "%{ZEPHYR_DOMU2_BUILD_DIR}/zephyr/zephyr.bin"
 
+  domu_unikraft:
+    default: true
+    build-dir: domu_unikraft
+
+    builder:
+      type: custom_script
+      script: "../%{YOCTOS_WORK_DIR}/meta-xt-rpi5-prod-devel/get_unikraft.sh"
+      target_images:
+        - "helloworld_xen-arm64"
+
   domd:
     build-dir: "%{YOCTOS_WORK_DIR}"
     sources:
@@ -239,6 +249,7 @@ images:
           "zephyr.bin": "%{ZEPHYR_DOM0_DIR}/%{ZEPHYR_DOM0_BUILD_DIR}/zephyr/zephyr.bin"
           "dom0/z_sync.bin": "%{ZEPHYR_DOMU1_DIR}/%{ZEPHYR_DOMU1_BUILD_DIR}/zephyr/zephyr.bin"
           "dom0/z_blinky.bin": "%{ZEPHYR_DOMU2_DIR}/%{ZEPHYR_DOMU2_BUILD_DIR}/zephyr/zephyr.bin"
+          "dom0/helloworld_xen-arm64": "domu_unikraft/helloworld_xen-arm64"
 
 parameters:
   # Machines
@@ -275,6 +286,7 @@ parameters:
                 items:
                   "dom0/z_sync.bin": "%{ZEPHYR_DOMU1_DIR}/%{ZEPHYR_DOMU1_BUILD_DIR}/zephyr/zephyr.bin"
                   "dom0/z_blinky.bin": "%{ZEPHYR_DOMU2_DIR}/%{ZEPHYR_DOMU2_BUILD_DIR}/zephyr/zephyr.bin"
+                  "dom0/helloworld_xen-arm64": "domu_unikraft/helloworld_xen-arm64"
 
   DOMD_ROOT:
     desc: "Domd root device"


### PR DESCRIPTION
Hence SD-card support is added the Zephyr guest domain images need to be
present on SD-card, so add generation of sync and blinky images.

Add unikernel monkey sample image binary to Dom0 storage for demo purposes.

Images stored in default for zephyr-dom0-xt folder "/dom0" on SD-card.