### PR TITLE
rpi5.yaml: fix zephyr dependencies

### DIFF
--- a/rpi5.yaml
+++ b/rpi5.yaml
@@ -40,7 +40,7 @@ components:
       target_images:
         - "%{ZEPHYR_DOM0_BUILD_DIR}/zephyr/zephyr.bin"
       additional_deps:
-        - "%{YOCTOS_WORK_DIR}/%{DOMD_BUILD_DIR}/tmp/deploy/images/%{MACHINE}/Image-%{MACHINE}.bin"
+        - "%{YOCTOS_WORK_DIR}/%{DOMD_BUILD_DIR}/tmp/deploy/images/%{MACHINE}/Image.gz"
 
   domd:
     build-dir: "%{YOCTOS_WORK_DIR}"


### PR DESCRIPTION
Path "rpi5.yaml: Correct target images for domd" did only half of the job: in changed name of output image for DomD, but it didn't changed dependency name for zephyr-dom0, so now build fails with the following message:

ninja: error: 'yocto/build-domd/tmp/deploy/images/raspberrypi5/Image.bin', needed by 'zephyr/build-dom0/zephyr/zephyr.bin', missing and no known rule to make it

Fix this by providing correct dependency name for Zephyr

Fixes: 3b4eb6839bd7 ("rpi5.yaml: Correct target images for domd")