### PR TITLE
rpi5.yaml: drop xen_dom0 snippet for dom0

### DIFF
--- a/rpi5.yaml
+++ b/rpi5.yaml
@@ -35,8 +35,6 @@ components:
       board: "%{ZEPHYR_DOM0_MACHINE}"
       target: "%{ZEPHYR_DOM0_TARGET}"
       work_dir: "%{ZEPHYR_DOM0_BUILD_DIR}"
-      snippets:
-        - "xen_dom0"
       target_images:
         - "%{ZEPHYR_DOM0_BUILD_DIR}/zephyr/zephyr.bin"
       additional_deps:


### PR DESCRIPTION
Do not use snippet for dom0 as it going to be dropped for zephyr-dom0-xt dom0 application [1].

[1] https://github.com/xen-troops/zephyr-dom0-xt/pull/18
Signed-off-by: Grygorii Strashko <grygorii_strashko@epam.com>