### PR TITLE
rpi5.yaml: roll back meta-raspberrypi to working commit

### DIFF
--- a/rpi5.yaml
+++ b/rpi5.yaml
@@ -59,7 +59,7 @@ components:
         rev: "scarthgap"
       - type: git
         url: "https://git.yoctoproject.org/meta-raspberrypi"
-        rev: "scarthgap"
+        rev: "1879cb831f4ea3e532cb5ce9fa0f32be917e8fa3"
       - type: git
         url: "https://github.com/xen-troops/meta-xt-common.git"
         rev: "master"


### PR DESCRIPTION
Recent changes in meta-raspberrypi causes build failures, so roll back to the commit known to be working.