### PR TITLE
rpi5.yaml: use http fetcher to get unikraft binary

### DIFF
--- a/get_unikraft.sh
+++ b/get_unikraft.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-wget https://github.com/aoscloud/demo-services/raw/main/monkey_zephyr/src/helloworld_xen-arm64 -O helloworld_xen-arm64
-

--- a/rpi5.yaml
+++ b/rpi5.yaml
@@ -1,5 +1,5 @@
 desc: "Raspberry 5 with xen dom0less"
-min_ver: "0.22"
+min_ver: "0.24"
 
 variables:
   # Common build configuration
@@ -83,12 +83,14 @@ components:
   domu_unikraft:
     default: true
     build-dir: domu_unikraft
+    sources:
+      - type: http
+        url: https://github.com/aoscloud/demo-services/raw/main/monkey_zephyr/src/helloworld_xen-arm64
+        file: helloworld_xen-arm64
+        dir: "."
 
     builder:
-      type: custom_script
-      script: "../%{YOCTOS_WORK_DIR}/meta-xt-rpi5-prod-devel/get_unikraft.sh"
-      target_images:
-        - "helloworld_xen-arm64"
+      type: "null"
 
   domd:
     build-dir: "%{YOCTOS_WORK_DIR}"


### PR DESCRIPTION
Moulin provides "http" fetcher to get unikraft binary from an external link.