### PR TITLE
rpi5.yaml: add "quiet" to domd bootargs

### DIFF
--- a/rpi5.yaml
+++ b/rpi5.yaml
@@ -366,7 +366,7 @@ parameters:
               conf:
                 - [DOMD_OVERLAYS, "%{SOC_FAMILY}-%{MACHINE}-usb.dtbo"]
                 - [MACHINE_FEATURES:append, " domd_usb"]
-                - [DOMD_BOOTARGS, "console=ttyAMA0 earlycon=xen earlyprintk=xen clk_ignore_unused root=\\\\/dev\\\\/sda1 rootfstype=ext4 rootwait"]
+                - [DOMD_BOOTARGS, "console=ttyAMA0 earlycon=xen earlyprintk=xen clk_ignore_unused root=\\\\/dev\\\\/sda1 rootfstype=ext4 rootwait quiet"]
         images:
           rootfs:
             type: gpt


### PR DESCRIPTION
Now the logs of Zephyr Dom0 and Linux DomD are mixed as they started in parallel by Xen in dom0less mode.

At this stage Zephyr Dom0 logs is more important, so add "quiet" to domd bootargs, so Zephyr Dom0 logs will be seen properly.