### PR TITLE
rpi5.yaml: Remove mmc rootfs option

### DIFF
--- a/rpi5.yaml
+++ b/rpi5.yaml
@@ -321,23 +321,6 @@ parameters:
 
   DOMD_ROOT:
     desc: "Domd root device"
-    mmc:
-      overrides:
-        components:
-          domd:
-            builder:
-              conf:
-                - [DOMD_OVERLAYS, "%{SOC_FAMILY}-%{MACHINE}-mmc.dtbo"]
-                - [MACHINE_FEATURES:append, " domd_mmc"]
-        images:
-          full:
-            partitions:
-              rootfs:
-                gpt_type: B921B045-1DF0-41C3-AF44-4C6F280D3FAE # Linux aarch64 root
-                type: raw_image
-                size: 8 GiB
-                image_path: "%{YOCTOS_WORK_DIR}/%{DOMD_BUILD_DIR}/tmp/deploy/images/%{MACHINE}/%{XT_DOMD_IMAGE}-%{MACHINE}.rootfs.ext4"
-
     usb:
       default: true
       overrides:


### PR DESCRIPTION
Remove rootfs on mmc for domd option. Currently only usb option available.