### PR TITLE
rpi5-image-xt-domd: install kernel modules to the image

### DIFF
--- a/xt-prod-devel-rpi5-domd/recipes-core/image/rpi5-image-xt-domd.bbappend
+++ b/xt-prod-devel-rpi5-domd/recipes-core/image/rpi5-image-xt-domd.bbappend
@@ -1,3 +1,7 @@
+PACKAGE_INSTALL:append = " \
+    kernel-modules \
+"
+
 IMAGE_INSTALL:append = "	\
     optee-test			\
 "


### PR DESCRIPTION
This change is moved from meta-xt-rpi5. Install all possible kernel modules in case if we need some of them.

---

This PR is complementary to https://github.com/xen-troops/meta-xt-rpi5/pull/18. They need to be fixed together.