### PR TITLE
Backport to v0.1: rpi5.yaml: set actual name for meta-xt-prod-devel-rpi5 repo

### DIFF
--- a/rpi5.yaml
+++ b/rpi5.yaml
@@ -49,7 +49,7 @@ common_data:
       url: "https://git.yoctoproject.org/meta-selinux"
       rev: "07f3233374f013412d691732adfa2c20167a0ea0"
     - type: git
-      url: "https://github.com/xen-troops/meta-xt-rpi5-prod-devel.git"
+      url: "https://github.com/xen-troops/meta-xt-prod-devel-rpi5.git"
       rev: "42db8f9e6d3ead1ec991d34c3244431ea7046b40"
 
   common_yocto_layers: &COMMON_YOCTO_LAYERS
@@ -182,7 +182,7 @@ components:
         - "../meta-xt-common/meta-xt-driver-domain"
         - "../meta-xt-common/meta-xt-security"
         - "../meta-xt-rpi5"
-        - "../meta-xt-rpi5-prod-devel/xt-prod-devel-rpi5-domd"
+        - "../meta-xt-prod-devel-rpi5/xt-prod-devel-rpi5-domd"
 
       target_images:
         - "tmp/deploy/images/%{MACHINE}/xen-%{MACHINE}"
@@ -248,7 +248,7 @@ components:
       layers:
         - *COMMON_YOCTO_LAYERS
         - "../meta-xt-common/meta-xt-domu"
-        - "../meta-xt-rpi5-prod-devel/xt-prod-devel-rpi5-domu"
+        - "../meta-xt-prod-devel-rpi5/xt-prod-devel-rpi5-domu"
 
       target_images:
         - "tmp/deploy/images/%{DOMU_MACHINE}/Image-initramfs-%{DOMU_MACHINE}.bin"


### PR DESCRIPTION
Since the main layer was renamed I have set an actual name to the repo which is meta-xt-prod-devel-rpi5.


Reviewed-by: Grygorii Strashko <grygorii_strashko@epam.com>
Reviewed-by: Volodymyr Babchuk <volodymyr_babchuk@epam.com>