### PR TITLE
rpi5.yaml: Release v0.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Build for the driver domain device is based on RPI5 bsp yocto build:
 
 ## Status
 
-This is release 0.2.0. This release supports the following features:
+This is release 0.2.1. This release supports the following features:
 
 * Zephyr operated control domain:
   * xen libraries integration that allows control of the other domains.
@@ -83,7 +83,7 @@ Below dependencies have to be satisfied before start building project:
 ```
 mkdir <my_build_dir>
 cd <my_build_dir>
-curl -O https://raw.githubusercontent.com/xen-troops/meta-xt-prod-devel-rpi5/v0.2.0/rpi5.yaml
+curl -O https://raw.githubusercontent.com/xen-troops/meta-xt-prod-devel-rpi5/v0.2.1/rpi5.yaml
 moulin rpi5.yaml
 ninja
 ```
@@ -1254,3 +1254,6 @@ ninja
 |        |           |   devices enabled                                 |
 |        |           | - add vchan utilities to the DomD                 |
 |        |           | - XSM security labeld configuration               |
+| v0.2.1 |           | Fixed:                                            |
+|        |           | - u-boot-scr: Don't override domd dtb addr        |
+|        |           | - domd: fix network irq issue                     |

--- a/rpi5.yaml
+++ b/rpi5.yaml
@@ -138,7 +138,7 @@ components:
         rev: "1918a27419dcd5e79954c0dc0edddcde91057a7e"
       - type: git
         url: "https://github.com/xen-troops/meta-xt-rpi5.git"
-        rev: "v0.2.0"
+        rev: "v0.2.1"
 
     builder:
       type: yocto


### PR DESCRIPTION
Incorporate fixes from meta-xt-rpi5 for the Release v0.2.1 and update Readme.