### PR TITLE
rpi5.yaml: switch zephyr to zephyr-v3.6.0-xt branch

### DIFF
--- a/rpi5.yaml
+++ b/rpi5.yaml
@@ -89,7 +89,7 @@ components:
     sources:
       - type: west
         url: "https://github.com/xen-troops/zephyr.git"
-        rev: "rpi5_dev"
+        rev: "zephyr-v3.6.0-xt"
 
     builder:
       type: zephyr
@@ -105,7 +105,7 @@ components:
     sources:
       - type: west
         url: "https://github.com/xen-troops/zephyr.git"
-        rev: "rpi5_dev"
+        rev: "zephyr-v3.6.0-xt"
 
     builder:
       type: zephyr


### PR DESCRIPTION
The zephyr-v3.6.0-xt is fully updated to support RPI5 so switch all Zephyr targets to use it.