### PR TITLE
[draft] Rpi5 scmi wifi

### DIFF
--- a/rpi5.yaml
+++ b/rpi5.yaml
@@ -51,7 +51,7 @@ common_data:
       rev: "scarthgap"
     - type: git
       url: "https://github.com/GrygiriiS/meta-xt-prod-devel-rpi5.git"
-      rev: "rpi5_scmi"
+      rev: "rpi5_scmi_wifi"
 
   common_yocto_layers: &COMMON_YOCTO_LAYERS
     - "../meta-openembedded/meta-oe"
@@ -143,7 +143,7 @@ components:
         rev: "scarthgap"
       - type: git
         url: "https://github.com/GrygiriiS/meta-xt-rpi5.git"
-        rev: "rpi5_scmi"
+        rev: "rpi5_scmi_wifi"
 
     builder:
       type: yocto
@@ -201,9 +201,11 @@ components:
         - "tmp/deploy/images/%{MACHINE}/%{SOC_FAMILY}-%{MACHINE}-usb.dtbo"
         - "tmp/deploy/images/%{MACHINE}/%{SOC_FAMILY}-%{MACHINE}-pcie1.dtbo"
         - "tmp/deploy/images/%{MACHINE}/%{XEN_DT_SCMI_NAME}.dtbo"
+        - "tmp/deploy/images/%{MACHINE}/%{SOC_FAMILY}-%{MACHINE}-wifi.dtbo"
         - "tmp/deploy/images/%{MACHINE}/mmc-passthrough.dtbo"
         - "tmp/deploy/images/%{MACHINE}/usb-passthrough.dtbo"
         - "tmp/deploy/images/%{MACHINE}/pcie1-passthrough.dtbo"
+        - "tmp/deploy/images/%{MACHINE}/wifi-passthrough.dtbo"
         - "tmp/deploy/images/%{MACHINE}/bcm2712-rpi-5-b.dtb"
         - "tmp/deploy/images/%{MACHINE}/%{XT_DOMD_IMAGE}-%{MACHINE}.rootfs.ext4"
         - "tmp/deploy/images/%{MACHINE}/Image.gz"
@@ -306,10 +308,12 @@ images:
           "mmc-passthrough.dtbo": "%{YOCTOS_WORK_DIR}/%{DOMD_BUILD_DIR}/tmp/deploy/images/%{MACHINE}/mmc-passthrough.dtbo"
           "usb-passthrough.dtbo": "%{YOCTOS_WORK_DIR}/%{DOMD_BUILD_DIR}/tmp/deploy/images/%{MACHINE}/usb-passthrough.dtbo"
           "pcie1-passthrough.dtbo": "%{YOCTOS_WORK_DIR}/%{DOMD_BUILD_DIR}/tmp/deploy/images/%{MACHINE}/pcie1-passthrough.dtbo"
+          "wifi-passthrough.dtbo": "%{YOCTOS_WORK_DIR}/%{DOMD_BUILD_DIR}/tmp/deploy/images/%{MACHINE}/wifi-passthrough.dtbo"
           "%{SOC_FAMILY}-%{MACHINE}-usb.dtbo": "%{YOCTOS_WORK_DIR}/%{DOMD_BUILD_DIR}/tmp/deploy/images/%{MACHINE}/%{SOC_FAMILY}-%{MACHINE}-usb.dtbo"
           "%{SOC_FAMILY}-%{MACHINE}-mmc.dtbo": "%{YOCTOS_WORK_DIR}/%{DOMD_BUILD_DIR}/tmp/deploy/images/%{MACHINE}/%{SOC_FAMILY}-%{MACHINE}-mmc.dtbo"
           "%{SOC_FAMILY}-%{MACHINE}-pcie1.dtbo": "%{YOCTOS_WORK_DIR}/%{DOMD_BUILD_DIR}/tmp/deploy/images/%{MACHINE}/%{SOC_FAMILY}-%{MACHINE}-pcie1.dtbo"
           "%{XEN_DT_SCMI_NAME}.dtbo": "%{YOCTOS_WORK_DIR}/%{DOMD_BUILD_DIR}/tmp/deploy/images/%{MACHINE}/%{XEN_DT_SCMI_NAME}.dtbo"
+          "%{SOC_FAMILY}-%{MACHINE}-wifi.dtbo": "%{YOCTOS_WORK_DIR}/%{DOMD_BUILD_DIR}/tmp/deploy/images/%{MACHINE}/%{SOC_FAMILY}-%{MACHINE}-wifi.dtbo"
           "zephyr.bin": "%{ZEPHYR_DOM0_DIR}/%{ZEPHYR_DOM0_BUILD_DIR}/zephyr/zephyr.bin"
       dom0:
         gpt_type: ebd0a0a2-b9e5-4433-87c0-68b6b72699c7
@@ -368,3 +372,17 @@ parameters:
               conf:
                 - [DOMD_OVERLAYS, "%{SOC_FAMILY}-%{MACHINE}-pcie1.dtbo"]
                 - [MACHINE_FEATURES:append, " domd_nvme"]
+
+  ENABLE_WIFI:
+    desc: "Allow wifi in domd"
+    yes:
+      overrides:
+        components:
+          domd:
+            builder:
+              conf:
+                - [MACHINE_FEATURES:append, " domd_wifi"]
+                - [LICENSE_FLAGS_ACCEPTED, "synaptics-killswitch"]
+                - [DOMD_OVERLAYS:append, " %{SOC_FAMILY}-%{MACHINE}-wifi.dtbo"]
+    no:
+      default: true

--- a/rpi5.yaml
+++ b/rpi5.yaml
@@ -25,6 +25,7 @@ variables:
   DOMU_BUILD_DIR: "build-domu"
   XT_XEN_DTBO_NAME: "%{SOC_FAMILY}-%{MACHINE}-xen.dtbo"
   XT_DOMD_DTB_NAME: "%{SOC_FAMILY}-%{MACHINE}-domd.dtb"
+  XEN_DT_SCMI_NAME: "%{SOC_FAMILY}-%{MACHINE}-scmi"
 
   XT_DOMD_IMAGE: "rpi5-image-xt-domd"
   XT_DOMU_IMAGE: "core-image-thin-initramfs"
@@ -77,6 +78,10 @@ components:
       work_dir: "%{ZEPHYR_DOM0_BUILD_DIR}"
       vars:
         - "CONFIG_DOM_STORAGE_FATFS_LOGICAL_DRIVE_NAME=\"1\""
+        - "CONFIG_ARM_SCMI=y"
+        - "CONFIG_RESET=y"
+        - "CONFIG_ARM_SCMI_SHELL=y"
+        - "CONFIG_ARM_SCMI_SMC_METHOD_HVC=y"
       target_images:
         - "%{ZEPHYR_DOM0_BUILD_DIR}/zephyr/zephyr.bin"
       additional_deps:
@@ -165,6 +170,7 @@ components:
         - [PREFERRED_VERSION_xen,"4.19.0+git"]
         - [PREFERRED_VERSION_xen-tools, "4.19.0+git"]
         - [PREFERRED_VERSION_u-boot, "2024.04"]
+        - [XEN_DT_SCMI, "%{XEN_DT_SCMI_NAME}"]
 
         # RPI specific
         - [ENABLE_UART, "1"]
@@ -174,6 +180,7 @@ components:
         - [KERNEL_IMAGETYPE_UBOOT, "Image"]
         - [DISTRO_FEATURES:append, " xen"]
         - [DOMD_BOOTARGS, "console=ttyAMA0 earlycon=xen earlyprintk=xen clk_ignore_unused root=%{DOMD_ROOTFS_DEV} rootfstype=ext4 rootwait quiet"]
+        - [MACHINE_FEATURES:append, " scmi"]
 
       build_target: "%{XT_DOMD_IMAGE}"
       layers:
@@ -193,6 +200,7 @@ components:
         - "tmp/deploy/images/%{MACHINE}/%{SOC_FAMILY}-%{MACHINE}-mmc.dtbo"
         - "tmp/deploy/images/%{MACHINE}/%{SOC_FAMILY}-%{MACHINE}-usb.dtbo"
         - "tmp/deploy/images/%{MACHINE}/%{SOC_FAMILY}-%{MACHINE}-pcie1.dtbo"
+        - "tmp/deploy/images/%{MACHINE}/%{XEN_DT_SCMI_NAME}.dtbo"
         - "tmp/deploy/images/%{MACHINE}/mmc-passthrough.dtbo"
         - "tmp/deploy/images/%{MACHINE}/usb-passthrough.dtbo"
         - "tmp/deploy/images/%{MACHINE}/pcie1-passthrough.dtbo"
@@ -301,6 +309,7 @@ images:
           "%{SOC_FAMILY}-%{MACHINE}-usb.dtbo": "%{YOCTOS_WORK_DIR}/%{DOMD_BUILD_DIR}/tmp/deploy/images/%{MACHINE}/%{SOC_FAMILY}-%{MACHINE}-usb.dtbo"
           "%{SOC_FAMILY}-%{MACHINE}-mmc.dtbo": "%{YOCTOS_WORK_DIR}/%{DOMD_BUILD_DIR}/tmp/deploy/images/%{MACHINE}/%{SOC_FAMILY}-%{MACHINE}-mmc.dtbo"
           "%{SOC_FAMILY}-%{MACHINE}-pcie1.dtbo": "%{YOCTOS_WORK_DIR}/%{DOMD_BUILD_DIR}/tmp/deploy/images/%{MACHINE}/%{SOC_FAMILY}-%{MACHINE}-pcie1.dtbo"
+          "%{XEN_DT_SCMI_NAME}.dtbo": "%{YOCTOS_WORK_DIR}/%{DOMD_BUILD_DIR}/tmp/deploy/images/%{MACHINE}/%{XEN_DT_SCMI_NAME}.dtbo"
           "zephyr.bin": "%{ZEPHYR_DOM0_DIR}/%{ZEPHYR_DOM0_BUILD_DIR}/zephyr/zephyr.bin"
       dom0:
         gpt_type: ebd0a0a2-b9e5-4433-87c0-68b6b72699c7

--- a/rpi5.yaml
+++ b/rpi5.yaml
@@ -50,8 +50,8 @@ common_data:
       url: "https://git.yoctoproject.org/meta-selinux"
       rev: "scarthgap"
     - type: git
-      url: "https://github.com/xen-troops/meta-xt-prod-devel-rpi5.git"
-      rev: "main"
+      url: "https://github.com/GrygiriiS/meta-xt-prod-devel-rpi5.git"
+      rev: "rpi5_scmi"
 
   common_yocto_layers: &COMMON_YOCTO_LAYERS
     - "../meta-openembedded/meta-oe"
@@ -68,8 +68,8 @@ components:
     build-dir: "%{ZEPHYR_DOM0_DIR}"
     sources:
       - type: west
-        url: "https://github.com/xen-troops/zephyr-dom0-xt.git"
-        rev: "rpi5_dom0_dev"
+        url: "https://github.com/GrygiriiS/zephyr-dom0-xt.git"
+        rev: "rpi5_dom0_dev_scmi"
 
     builder:
       type: zephyr
@@ -142,8 +142,8 @@ components:
         url: "https://git.yoctoproject.org/meta-raspberrypi"
         rev: "scarthgap"
       - type: git
-        url: "https://github.com/xen-troops/meta-xt-rpi5.git"
-        rev: "main"
+        url: "https://github.com/GrygiriiS/meta-xt-rpi5.git"
+        rev: "rpi5_scmi"
 
     builder:
       type: yocto

--- a/xt-prod-devel-rpi5-domd/recipes-core/image/rpi5-image-xt-domd.bbappend
+++ b/xt-prod-devel-rpi5-domd/recipes-core/image/rpi5-image-xt-domd.bbappend
@@ -2,7 +2,16 @@ PACKAGE_INSTALL:append = " \
     kernel-modules \
 "
 
+WIFI_PACKAGES = "			\
+    wpa-supplicant			\
+    iw					\
+    wireless-regdb-static		\
+    linux-firmware-rpidistro-bcm43455	\
+    kernel-module-brcmfmac		\
+"
+
 IMAGE_INSTALL:append = "	\
     optee-test			\
     xen-tools-vchan		\
+    ${@bb.utils.contains("MACHINE_FEATURES", "domd_wifi", "${WIFI_PACKAGES}", "" ,d)} \
 "


### PR DESCRIPTION
Enable WIFI with scmi.

Based on PR#38

Note. Xen and ARM TF still need to be updated manually.