### PR TITLE
yaml: do not resize domd's rootfs

### DIFF
--- a/layers/xt-prod-devel-rpi5-domd/recipes-core/image/rpi5-image-xt-domd.bbappend
+++ b/layers/xt-prod-devel-rpi5-domd/recipes-core/image/rpi5-image-xt-domd.bbappend
@@ -15,3 +15,6 @@ IMAGE_INSTALL:append = "	\
     xen-tools-vchan		\
     ${@bb.utils.contains("MACHINE_FEATURES", "domd_wifi", "${WIFI_PACKAGES}", "" ,d)} \
 "
+
+# rootfs have to be 8 GiB, expressed in KiB
+IMAGE_ROOTFS_SIZE = "8388608"

--- a/rpi5.yaml
+++ b/rpi5.yaml
@@ -308,7 +308,6 @@ images:
       rootfs:
         gpt_type: B921B045-1DF0-41C3-AF44-4C6F280D3FAE # Linux aarch64 root
         type: raw_image
-        size: 8 GiB
         image_path: "%{YOCTOS_WORK_DIR}/%{DOMD_BUILD_DIR}/tmp/deploy/images/%{MACHINE}/%{XT_DOMD_IMAGE}-%{MACHINE}.rootfs.ext4"
 
 parameters:


### PR DESCRIPTION
Original code
```
        type: raw_image
        size: 8 GiB
        image_path: "....domd.ext4"
```
worked in this way: the 8GiB partition was created, and rootfs was placed with its original size of about 1GiB. The remaining 7GiB were unusable.

At some point, we made a change to the moulin and started resizing ext4 images to fit the partition of the requested size. However, this resizing happens in the host environment, while the ext4 image is created inside the yocto environment.

Package `e2fsprogs` was upgraded to version 1.47 in the yocto 4.2. And that version uses new options during the creation of the ext4 images. The same version of the `e2fsprogs` is provided with the Ubuntu 23+. At the same time, these new options are not supported by the previous versions of the `e2fsprogs` provided with Ubuntu 20...22.
As result, resize2fs on the Ubuntu 20 host can't resize ext4 image created by the tools used in the scarthgap.

So, the only fast solution for now is to use `resize: false` so we will not try to resize not supported image.