### PR TITLE
Fix linux version mismatch

### DIFF
--- a/rpi5.yaml
+++ b/rpi5.yaml
@@ -161,6 +161,7 @@ components:
         - [PREFERRED_VERSION_xen-tools, "4.19.0+git"]
         - [PREFERRED_VERSION_u-boot, "2024.04"]
         - [XEN_DT_SCMI, "%{XEN_DT_SCMI_NAME}"]
+        - [PREFERRED_VERSION_linux-raspberrypi, "6.6.%"]
         # RPI specific
         - [ENABLE_UART, "1"]
         - [RPI_USE_U_BOOT, "1"]

--- a/rpi5.yaml
+++ b/rpi5.yaml
@@ -34,19 +34,19 @@ common_data:
   common_yocto_sources: &COMMON_YOCTO_SOURCES
     - type: git
       url: "https://git.yoctoproject.org/poky"
-      rev: "scarthgap"
+      rev: "7bb9c2255b3aed8441fba1133f350b223a3b6379"
     - type: git
       url: "https://git.openembedded.org/meta-openembedded"
-      rev: "scarthgap"
+      rev: "727811eaf256b88fd135be99559f2cbf14c82fce"
     - type: git
       url: "https://github.com/xen-troops/meta-xt-common.git"
-      rev: "master"
+      rev: "3f17cfe7a64491ff854a34aa76a90b3235723bc1"
     - type: git
       url: "https://git.yoctoproject.org/meta-virtualization"
-      rev: "scarthgap"
+      rev: "9e040ee8dd6025558ea60ac9db60c41bfeddf221"
     - type: git
       url: "https://git.yoctoproject.org/meta-selinux"
-      rev: "scarthgap"
+      rev: "c4b059262089b74c8fbf8dd5fdf5fd7bc1deeddc"
 
   common_yocto_layers: &COMMON_YOCTO_LAYERS
     - "../meta-openembedded/meta-oe"
@@ -143,7 +143,7 @@ components:
       - *COMMON_YOCTO_SOURCES
       - type: git
         url: "https://git.yoctoproject.org/meta-raspberrypi"
-        rev: "scarthgap"
+        rev: "48452445d779b0f69bf1ead12b3850d50eb8920d"
       - type: git
         url: "https://github.com/xen-troops/meta-xt-rpi5.git"
         rev: "main"


### PR DESCRIPTION
Build on main failed with output
```
Traceback (most recent call last):
  File "/home/xtrs/.local/bin/rouge", line 8, in <module>
    sys.exit(rouge_entry())
  File "/home/xtrs/.local/lib/python3.8/site-packages/moulin/main.py", line 209, in rouge_entry
    fileo.truncate(block_entry.size())
  File "/home/xtrs/.local/lib/python3.8/site-packages/moulin/rouge/block_entry.py", line 70, in size
    self._complete_init()
  File "/home/xtrs/.local/lib/python3.8/site-packages/moulin/rouge/block_entry.py", line 94, in _complete_init
    partitions = [x._replace(size=x.entry.size()) for x in self._partitions]
  File "/home/xtrs/.local/lib/python3.8/site-packages/moulin/rouge/block_entry.py", line 94, in <listcomp>
    partitions = [x._replace(size=x.entry.size()) for x in self._partitions]
  File "/home/xtrs/.local/lib/python3.8/site-packages/moulin/rouge/block_entry.py", line 276, in size
    self._complete_init()
  File "/home/xtrs/.local/lib/python3.8/site-packages/moulin/rouge/block_entry.py", line 246, in _complete_init
    raise YAMLProcessingError(f"Can't find file '{local_name}'", local_mark)
moulin.yaml_helpers.YAMLProcessingError: Can't find file 'yocto/build-domd/tmp/deploy/images/raspberrypi5/Image.gz'   in "rpi5.yaml", line 275, column 23
FAILED: full.img 
rouge rpi5.yaml -fi full -o full.img
ninja: build stopped: subcommand failed.
```

This is caused by linux version mismatch: meta-raspberrypi set the preferred version as 6.12.%, while meta-xt-prod-devel-rpi5 is based on the 6.6.

That is why a setting version in the yaml file was added, which will effectively override the default value from the meta-raspberry. And to avoid similar future issues the commit hashes were set instead of branch names.

Fixes: https://github.com/xen-troops/meta-xt-prod-devel-rpi5/issues/53

@firscity @lorc @GrygiriiS @oleksiimoisieiev @rshym