### PR TITLE
yaml: Add CAN support for both chips

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,11 @@ line option:
 
 ```
 $ moulin rpi5.yaml --help-config
-usage: moulin rpi5.yaml [--MACHINE {rpi5}] [--DOMD_ROOT {usb,nvme}] [--ENABLE_SCMI {yes,no}] [--ENABLE_WIFI {yes,no}] [--ENABLE_CAN {yes,no}]
+usage: moulin rpi5.yaml [--MACHINE {rpi5}] [--DOMD_ROOT {usb,nvme}] [--ENABLE_SCMI {yes,no}] [--ENABLE_WIFI {yes,no}] [--ENABLE_CAN {mcp2515-can,seeed-can-fd-hat-v2,no}]
 
 Config file description: Raspberry 5 with xen dom0less
 
-optional arguments:
+options:
   --MACHINE {rpi5}      Raspberry Pi machines (default: rpi5)
   --DOMD_ROOT {usb,nvme}
                         Domd root device (default: usb)
@@ -54,15 +54,37 @@ optional arguments:
                         Enable ARM SCMI support (default: no)
   --ENABLE_WIFI {yes,no}
                         Allow wifi in domd (default: no)
-  --ENABLE_CAN {yes,no}
-                        Allow CAN in domd (default: no)
+  --ENABLE_CAN {mcp2515-can,seeed-can-fd-hat-v2,no}
+                        Allow CAN in DomD and choose it type. The naming of options align with the overlay naming used in RPI OS (default: no)
 ```
 
-You can choose root device for the DomD, enable SCMI, WiFi and CAN.
+You can choose root device and CAN for the DomD, enable SCMI, and WiFi.
 
 Moulin will generate `build.ninja` file. After that run `ninja` to
 build the image. This will take some time and disk space as it builds
 a few separate OS images.
+
+##### CAN options
+
+The naming of supported CAN options is chosen to align with the overlay
+naming conventions in RPI OS. Making it easier for users who are already
+familiar with and have experience using supported HATs in RPI OS to
+seamlessly transition to our product.
+
+The required overlay(s) can be easily found in the relevant documentation
+for the specific HAT. For now supported:
+
+- `mcp2515-can` is the option for the **2-CH CAN HAT** with the MCP2515 chip
+  ([documentation](https://www.waveshare.com/wiki/2-CH_CAN_HAT#Documentation)).
+- `seeed-can-fd-hat-v2` is the option for the **2-Channel CAN BUS FD Shield**
+ with the MCP251XFD chip
+  ([documentation](https://wiki.seeedstudio.com/2-Channel-CAN-BUS-FD-Shield-for-Raspberry-Pi/)).
+
+Additionally, note that enabling the `mcp2515-can` option corresponds to
+enabling the mcp2515-can0 and mcp2515-can1 overlays in RPI OS, which
+are not exclusive to the **2-CH CAN HAT**. Therefore, if you are using any
+other CAN HAT with the MCP2515 chip that requires these overlays, it
+may also work.
 
 #### Build products
 

--- a/rpi5.yaml
+++ b/rpi5.yaml
@@ -30,6 +30,8 @@ variables:
 
   DOMU_MACHINE: "generic-armv8-xt"
 
+  DOMD_CAN_TYPE: ""
+
 common_data:
   common_yocto_sources: &COMMON_YOCTO_SOURCES
     - type: git
@@ -170,6 +172,7 @@ components:
         - [KERNEL_IMAGETYPE_UBOOT, "Image"]
         - [DISTRO_FEATURES:append, " xen"]
         - [DOMD_BOOTARGS, "console=ttyAMA0 earlycon=xen earlyprintk=xen clk_ignore_unused root=%{DOMD_ROOTFS_DEV} rootfstype=ext4 rootwait quiet"]
+        - [DOMD_CAN_TYPE, "%{DOMD_CAN_TYPE}"]
       build_target: "%{XT_DOMD_IMAGE}"
       layers:
         - *COMMON_YOCTO_LAYERS
@@ -382,23 +385,43 @@ parameters:
       default: true
 
   ENABLE_CAN:
-    desc: "Allow CAN in domd"
-    yes:
+    desc: "Allow CAN in DomD and choose it type. The naming of options align with the overlay naming used in RPI OS"
+    mcp2515-can:
       overrides:
+        variables:
+          DOMD_CAN_TYPE: "mcp2515"
         components:
           domd:
             builder:
               conf:
                 - [MACHINE_FEATURES:append, " domd_can"]
-                - [DOMD_OVERLAYS:append, " %{SOC_FAMILY}-%{MACHINE}-can.dtbo"]
+                - [DOMD_OVERLAYS:append, " %{SOC_FAMILY}-%{MACHINE}-can-%{DOMD_CAN_TYPE}.dtbo"]
               target_images:
-                - "tmp/deploy/images/%{MACHINE}/%{SOC_FAMILY}-%{MACHINE}-can.dtbo"
-
+                - "tmp/deploy/images/%{SOC_FAMILY}-%{MACHINE}-can-%{DOMD_CAN_TYPE}.dtbo"
         images:
           full:
             partitions:
               boot:
                 items:
-                  "%{SOC_FAMILY}-%{MACHINE}-can.dtbo": "%{YOCTOS_WORK_DIR}/%{DOMD_BUILD_DIR}/tmp/deploy/images/%{MACHINE}/%{SOC_FAMILY}-%{MACHINE}-can.dtbo"
+                  "%{SOC_FAMILY}-%{MACHINE}-can-%{DOMD_CAN_TYPE}.dtbo": "%{YOCTOS_WORK_DIR}/%{DOMD_BUILD_DIR}/tmp/deploy/images/%{MACHINE}/%{SOC_FAMILY}-%{MACHINE}-can-%{DOMD_CAN_TYPE}.dtbo"
+
+    seeed-can-fd-hat-v2:
+      overrides:
+        variables:
+          DOMD_CAN_TYPE: "seeed-fd"
+        components:
+          domd:
+            builder:
+              conf:
+                - [MACHINE_FEATURES:append, " domd_can"]
+                - [DOMD_OVERLAYS:append, " %{SOC_FAMILY}-%{MACHINE}-can-%{DOMD_CAN_TYPE}.dtbo"]
+              target_images:
+                - "tmp/deploy/images/%{SOC_FAMILY}-%{MACHINE}-can-%{DOMD_CAN_TYPE}.dtbo"
+        images:
+          full:
+            partitions:
+              boot:
+                items:
+                  "%{SOC_FAMILY}-%{MACHINE}-can-%{DOMD_CAN_TYPE}.dtbo": "%{YOCTOS_WORK_DIR}/%{DOMD_BUILD_DIR}/tmp/deploy/images/%{MACHINE}/%{SOC_FAMILY}-%{MACHINE}-can-%{DOMD_CAN_TYPE}.dtbo"
     no:
       default: true


### PR DESCRIPTION
If the CAN_ENABLE is set to yes, the CAN works only with the 2-CH CAN HAT with the MCP2515 chip. Also, in release 0.3.1 of meta-xt-rpi5, a device tree overlay to support the 2 Channel CAN BUS FD Shield with the MCP251XFD chip was added.

Therefore, added the possibility to choose the CAN chip between the previously mentioned two options by setting the `CAN_ENABLE` to `mcp2515` or `seeed_fd` accordingly, which also sets the `DOMD_CAN_TYPE` configuration to enable the required device tree overlay.

Related to: https://github.com/xen-troops/meta-xt-rpi5/pull/41

@firscity @lorc @GrygiriiS @oleksiimoisieiev @rshym